### PR TITLE
Use PortableRunner instead of FlinkRunner in wordcount job.

### DIFF
--- a/beam-on-flink-operator/beam_job_server.yaml
+++ b/beam-on-flink-operator/beam_job_server.yaml
@@ -24,10 +24,10 @@ metadata:
 spec:
   ports:
     - name: job
-      port: 8098
-      targetPort: 8098
-    - name: artifact
       port: 8099
       targetPort: 8099
+    - name: artifact
+      port: 8098
+      targetPort: 8098
   selector:
     app: beam-job-server

--- a/beam-on-flink-operator/beam_wordcount_py.yaml
+++ b/beam-on-flink-operator/beam_wordcount_py.yaml
@@ -16,9 +16,7 @@ spec:
           args:
             - "-m"
             - "apache_beam.examples.wordcount"
-            - "--runner=FlinkRunner"
-            - "--flink_version=1.8"
-            - "--flink_master=beam-flink-cluster-jobmanager:8081"
+            - "--runner=PortableRunner"
             - "--job_endpoint=beam-job-server:8099"
             - "--artifact_endpoint=beam-job-server:8098"
             - "--environment_type=EXTERNAL"


### PR DESCRIPTION
We can use FlinkRunner after supporting Kubernetes by making some changes in Beam.